### PR TITLE
Add tooltip on ATR label explaining Average True Range

### DIFF
--- a/watchlist.html
+++ b/watchlist.html
@@ -570,8 +570,8 @@ function openDetail(symbol) {
   const volItems = [
     ['RSI (14)', t.rsi != null ? `${t.rsi}${t.rsi > 70 ? ' OB <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="bt-icon"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><circle cx="12" cy="16" r="0.5" fill="currentColor"/></svg>' : t.rsi < 30 ? ' OS <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="bt-icon"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>' : ''}` : '—',
       t.rsi > 70 ? 'color:var(--red)' : t.rsi < 30 ? 'color:var(--cyan)' : ''],
-    ['ATR (14)', t.atr != null ? `$${t.atr.toFixed(2)}` : '—', ''],
-    ['ATR %', t.atrPct != null ? `${t.atrPct}%` : '—', ''],
+    ['<span title="Average True Range — measures volatility based on the stock\'s price range over 14 periods">ATR (14)</span>', t.atr != null ? `$${t.atr.toFixed(2)}` : '—', ''],
+    ['<span title="ATR as a percentage of the stock price — normalizes volatility for comparison across different price levels">ATR %</span>', t.atrPct != null ? `${t.atrPct}%` : '—', ''],
     ['Vol Rating', t.volRating || '—', ''],
     ['Volume', t.volume != null ? fmtVol(t.volume) : '—', ''],
     ['vs 20d Avg', t.volumeRatio != null ? `${t.volumeRatio}x` : '—',


### PR DESCRIPTION
Adds title attribute tooltips to ATR (14) and ATR% labels in the watchlist detail modal, explaining what they mean in plain English.

Closes #1