### PR TITLE
feat(em): unlock history data, smarter triage on EM page

### DIFF
--- a/openspec/INDEX.md
+++ b/openspec/INDEX.md
@@ -113,6 +113,7 @@ Vanilla JS SPA in `root ` subdirectory. Hash router, persistent nav + ticker tap
 |--------|--------|-------------|
 | [SPA v2 Cutover](changes/spa-root OPENSPEC.md) | Phase 4 pending | Move `root ` to root, archive v1, configure auth, custom domain |
 | [Data Pipeline](changes/data-pipeline/) | Partial | Core signals + EOD pipeline shipped; lifecycle classifier + per-ticker Tom pending |
+| [EM History Sparkline + Triage UX](changes/em-history-sparkline/OPENSPEC.md) | PR open | v1 EM page: detail-modal history chart (price vs predicted EM band), IV Trend column (replaces redundant Risk Meter), bias-aware Buy Zone/Extended stats, alert-tag filter chips, default sort = position ASC, stale-data top banner. Single-file change (`v1/expected-moves.html`) + 22 new Jest tests. v2 SPA parity tracked as follow-up. |
 
 ## Planned Changes (not started)
 
@@ -129,7 +130,7 @@ Vanilla JS SPA in `root ` subdirectory. Hash router, persistent nav + ticker tap
 | SPA v2 Cutover (Phase 4) | **Medium** | Retire v1, configure Azure SWA auth + custom domain. v2 SPA is production. |
 | [Regime Intelligence Dashboard](changes/regime-intelligence/OPENSPEC.md) | **Shipped** | ✅ Shipped as AI Researcher (`#airesearcher`). Computed regime score from 15 weighted signals, 7 regimes (CRISIS→EUPHORIA), Tom's rules mapped, playbook per regime, transition signals, market internals, commodity chain, regime history. Added to EOD pipeline. |
 | Earnings Calendar | High | Dedicated earnings tool — EarningsWhisper (primary), TradingView (secondary). Upcoming earnings for watchlist + broader market. |
-| EM History Sparkline | Medium | Per-ticker mini sparkline of historical EM values on expected-moves.html. *Partially addressed by Quarterly EM History (2026-04-03) — quarterly range bars in detail modal. Inline table sparkline still planned.* |
+| EM History Sparkline | Medium | Per-ticker mini sparkline of historical EM values on expected-moves.html. *Partially addressed by Quarterly EM History (2026-04-03) — quarterly range bars in detail modal. Now in progress: see Active Changes → "EM History Sparkline + Triage UX".* |
 | EM Columns on Watchlist | Medium | Compact weekly EM% + position in range columns on watchlist table |
 | [AI-Ready Architecture](changes/ai-ready-architecture/) | Medium | Tom agent multi-channel output: alerts, ticker notes, market pulse, feed panel |
 | Trade Lifecycle Engine | Medium | 9-state status classifier for ticker cards |

--- a/openspec/changes/em-history-sparkline/OPENSPEC.md
+++ b/openspec/changes/em-history-sparkline/OPENSPEC.md
@@ -1,0 +1,138 @@
+# EM History Sparkline + Triage UX — OpenSpec
+
+> Created: 2026-05-09
+> Status: **In Progress**
+> Priority: **Medium**
+> Page: `v1/expected-moves.html`
+> Tracking: was Planned in INDEX.md ("EM History Sparkline — Inline table sparkline still planned")
+
+## Problem
+
+The Expected Moves page is a **triage tool** ("which tickers are at the bottom of their range, and which are stretched") but four pieces of data the producer already writes are unused or under-used:
+
+1. **`history[]`** (up to 33 daily snapshots per ticker) is never rendered. The detail modal shows only the current tier cards. Traders cannot see whether a ticker's been near support for one day or four weeks straight (= losing edge).
+2. **`weekly_em` and `straddle` over time** — the page has no sense of whether implied vol is expanding or contracting.
+3. **`watchlist[].bias`** — used per row, but the stats row counts buy-zone tickers without breaking down by bias. A bullish-biased ticker in buy zone is the highest-conviction long setup; mixed in with bears, the count is muddied.
+4. **The Risk Meter column duplicates the Position in Range column** — both render a colored bar whose width is `position%`. Dead pixel real estate.
+
+Other ergonomics gaps:
+
+5. **No alert-tag filter** — table can be filtered by symbol category, but not by "show me only buy zones / extended / outside EM".
+6. **No useful default sort** — when no user sort is active, order is JSON insertion order (effectively `DEFAULT_TICKERS` order in the producer). Buy-zones do not float to the top.
+7. **Stale-data UX is hidden** — when EM data is >48h old, only the timestamp turns red. The original Mar 27 staleness bug (writeup in `expected-moves/proposal.md`) showed users miss the timestamp; the page misled while looking authoritative.
+
+## Goals
+
+Make the triage faster and more credible by surfacing what's already in the data:
+
+- **Detail modal:** add a 30-day "EM band vs realized close" chart so a click reveals whether this ticker has been respecting its EM (and where it broke).
+- **Inline table:** replace the redundant Risk Meter column with an **IV Trend** indicator (▲/▼/—) computed from the history array.
+- **Stats row:** break down Buy Zone and Extended counts by watchlist bias.
+- **Filters:** add Buy Zone / Extended / Outside EM chips that AND with the existing category filter.
+- **Default sort:** position ASC when no user sort is active (buy-zones at top).
+- **Stale banner:** when data is >48h old, show a top-of-page banner — not just a red timestamp.
+
+## Non-Goals
+
+- No producer changes. All data already exists in `data/expected-moves.json`.
+- No quarterly history work — that already shipped in v2 (`js/pages/expected-moves.js`) and is tracked under `Quarterly EM History` (2026-04-03).
+- No v2 SPA changes in this PR. v1 is production; v2 will get the same treatment in a follow-up.
+- No new dependencies. SVG is rendered inline (no chart library).
+
+## Design
+
+### 1. Detail-modal history chart
+
+Inline `<svg>` (~360×140) inside `#em-modal-body`, between the TradingView chart and the tier cards. For each ticker:
+
+- X axis: latest N snapshots from `history[]` (N = up to 30, fewer if history is shorter).
+- Y axis: `close`. Y range = `[min(close, lower) − 1%, max(close, upper) + 1%]`.
+- **Shaded band:** `<polygon>` between `close + weekly_em` (upper) and `close − weekly_em` (lower) for each snapshot — the predicted EM range as it evolved.
+- **Price line:** `<polyline>` of `close`.
+- **Breach markers:** `<circle r="3">` on snapshots where `close > prev.close + prev.weekly_em` or `close < prev.close − prev.weekly_em` (i.e. that day's close moved beyond the previous snapshot's predicted band). Color: red if up-breach, cyan if down-breach.
+- **Caption below chart:** `Last N days · K breach(es) · IV trend ▲/▼/— X%`.
+
+For tickers with `history.length < 2`, the section is omitted (no chart shown).
+
+### 2. IV Trend column (replaces Risk Meter)
+
+Computed in `buildRows()` from the same `history[]`:
+
+```
+recentEM   = mean(weekly_em over last 5 history entries) || current weekly_em
+priorEM    = mean(weekly_em over the 5 entries before that) || recentEM
+trendPct   = (recentEM − priorEM) / priorEM × 100
+```
+
+Display:
+- `▲ +X%` red — IV expansion (≥+5%)
+- `▼ −X%` green — IV contraction (≤−5%)
+- `— flat` gray — between −5% and +5%
+- `—` gray dim — insufficient history (< 4 entries)
+
+Rationale: rising IV = options are pricing bigger moves than they were a week ago = expect bigger EM ranges going forward. Falling IV = consolidation. Knowing direction qualifies the static EM%.
+
+Sortable: by `trendPct` numerically.
+
+### 3. Bias-aware stats
+
+Replace flat counts with `total (X bull / Y bear / Z mixed)` for Buy Zone and Extended cards. Bias source is the existing `watchlistData.find(w => w.symbol === sym).bias` already computed per row.
+
+### 4. Alert-tag filter chips
+
+New filter row `.alert-filter-tabs` below the existing tier+filter row, with three chips:
+
+- 🟢 Buy Zone (`position ≤ 20`)
+- 🔴 Extended (`position ≥ 85`)
+- ⚡ Outside EM (`position < 0 or position > 100`)
+
+Click toggles. Multiple chips can be active = OR (any match passes). When no chip is active, behavior is unchanged. AND-ed with the existing All / Indices / Top10 / Watchlist filter.
+
+### 5. Smart default sort
+
+When `sortCol === null`, sort by position ASC. The `sortRows()` change is one line. User clicks on any header still override and can return to "default sort" via the third state of the cycle (currently clears sort, after change defaults to position ASC).
+
+### 6. Stale-data banner
+
+If `ageHours > 48`, prepend a `.stale-banner` div above the stats row:
+`⚠️ Expected Move data is X days old. Run update-expected-moves.py to refresh.`
+Background red, no dismiss (returns automatically when fresh data arrives).
+
+## File Touches
+
+- `v1/expected-moves.html` — single file, ~120 lines added/changed (CSS + JS + markup).
+- `tests/em-page-improvements.test.js` — new Jest file with unit tests for IV trend, default sort, bias-aware stats, alert-tag filter, and history-chart guard.
+- `openspec/INDEX.md` — move "EM History Sparkline" row from Planned → Active, then Shipped after merge.
+- `docs/EXPECTED_MOVES_PAGE.md` — added/updated to reflect new columns + filters (if file exists; created if not).
+
+## Test Plan
+
+- `cd tests && npx jest` — must remain at 137 + new test count, 0 failures.
+- `node tests/test-em-formula.js` — must remain at the same pass count (167) with no new failures (the 42 pre-existing failures are date-based on stale data and out of scope).
+- Manual smoke (browser, `python3 -m http.server`):
+  - Load `v1/expected-moves.html`. Buy zones float to top.
+  - Click a ticker with history. Modal shows price-vs-band chart.
+  - Toggle a filter chip. Rows narrow correctly.
+  - Switch tier. Default sort still applies.
+  - Force `ageHours > 48` (mock `data/expected-moves.json` with old `updated`). Banner appears.
+
+## Risk
+
+- **Sort default change** is user-visible. Mitigation: still cycle-able, third click returns to default (position ASC). Documented in PR body.
+- **Risk Meter column removal** is user-visible. Mitigation: Position in Range already shows the same information with a clearer label.
+- **History rendering** must guard against missing/short history arrays — covered in tests.
+
+## Rollout
+
+1. Land PR on `breakingtrades/breakingtrades-dashboard:main`.
+2. GitHub Pages auto-deploys.
+3. Update INDEX.md row to Shipped with commit hash.
+4. Open follow-up issue for v2 SPA (`js/pages/expected-moves.js`) parity.
+
+## Out of scope (follow-ups)
+
+- v2 SPA parity (separate PR).
+- Mobile card view at ≤768px (separate PR; existing horizontal scroll is acceptable for now).
+- CSV export (separate PR).
+- Bias-by-tier breakdown (compare bullish-buy-zone weekly vs monthly).
+- EM-breach Telegram alerts (already tracked in `em-reliability-improvements`).

--- a/tests/em-page-improvements.test.js
+++ b/tests/em-page-improvements.test.js
@@ -1,0 +1,350 @@
+/**
+ * EM Page Improvements — Unit Tests
+ *
+ * Tests the data helpers added by `feat/em-history-sparkline`:
+ *   - computeIVTrend(history, anchorClose)
+ *   - buildHistoryChart(ticker, maxPoints)
+ *   - biasBreakdown(rows)
+ *   - default-sort behavior (position ASC when no sortCol)
+ *   - alert-tag filter logic
+ *
+ * The implementations live as inline <script> in v1/expected-moves.html.
+ * To unit-test them without a browser we extract their function bodies
+ * by string-matching, then `eval` them inside this Jest module.
+ *
+ * If the file structure changes (function rename / signature drift) these
+ * tests will fail loudly — that is the intent.
+ *
+ * Run: cd tests && npx jest em-page-improvements.test.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HTML_PATH = path.join(__dirname, '..', 'v1', 'expected-moves.html');
+const html = fs.readFileSync(HTML_PATH, 'utf8');
+
+// Pull a `function NAME(...)` block out of the inline <script>.
+// Greedy-match braces with a simple depth counter.
+function extractFn(name) {
+  const start = html.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`function ${name} not found in expected-moves.html`);
+  const openBrace = html.indexOf('{', start);
+  let depth = 1;
+  let i = openBrace + 1;
+  while (i < html.length && depth > 0) {
+    const ch = html[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+    i++;
+  }
+  return html.slice(start, i);
+}
+
+// Build a sandbox that has just enough globals for the extracted functions.
+const sandbox = { window: {} };
+sandbox.global = sandbox;
+
+// Pull dependent helpers in order. computeIVTrend has no deps; buildHistoryChart
+// has no deps; biasBreakdown has no deps. Order doesn't matter functionally.
+const SOURCES = ['computeIVTrend', 'buildHistoryChart', 'biasBreakdown'].map(extractFn);
+
+// eslint-disable-next-line no-new-func
+const installer = new Function('window', SOURCES.join('\n') + `
+  window.computeIVTrend = computeIVTrend;
+  window.buildHistoryChart = buildHistoryChart;
+  window.biasBreakdown = biasBreakdown;
+`);
+installer(sandbox.window);
+
+const { computeIVTrend, buildHistoryChart, biasBreakdown } = sandbox.window;
+
+// ──────────────────────────────────────────────────────────────────────────
+// computeIVTrend
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('computeIVTrend', () => {
+  test('returns empty when history is missing or too short', () => {
+    expect(computeIVTrend(null, 100).kind).toBe('empty');
+    expect(computeIVTrend([], 100).kind).toBe('empty');
+    expect(computeIVTrend([{close: 100, weekly_em: 1}], 100).kind).toBe('empty');
+    expect(computeIVTrend([{close: 100, weekly_em: 1},{close:100,weekly_em:1},{close:100,weekly_em:1}], 100).kind).toBe('empty');
+  });
+
+  test('flat trend produces "flat" kind', () => {
+    const hist = [];
+    for (let i = 0; i < 10; i++) hist.push({ close: 100, weekly_em: 1.0 });
+    const r = computeIVTrend(hist, 100);
+    expect(r.kind).toBe('flat');
+    expect(Math.abs(r.delta)).toBeLessThan(5);
+  });
+
+  test('rising IV gives "up" kind with positive delta', () => {
+    const hist = [
+      // prior 5 — em% = 1%
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      // recent 5 — em% = 1.5% → +50%
+      { close: 100, weekly_em: 1.5 },
+      { close: 100, weekly_em: 1.5 },
+      { close: 100, weekly_em: 1.5 },
+      { close: 100, weekly_em: 1.5 },
+      { close: 100, weekly_em: 1.5 },
+    ];
+    const r = computeIVTrend(hist, 100);
+    expect(r.kind).toBe('up');
+    expect(r.delta).toBeGreaterThanOrEqual(5);
+    expect(r.label).toMatch(/▲/);
+  });
+
+  test('contracting IV gives "down" kind with negative delta', () => {
+    const hist = [
+      { close: 100, weekly_em: 2.0 },
+      { close: 100, weekly_em: 2.0 },
+      { close: 100, weekly_em: 2.0 },
+      { close: 100, weekly_em: 2.0 },
+      { close: 100, weekly_em: 2.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+    ];
+    const r = computeIVTrend(hist, 100);
+    expect(r.kind).toBe('down');
+    expect(r.delta).toBeLessThanOrEqual(-5);
+    expect(r.label).toMatch(/▼/);
+  });
+
+  test('handles missing close in snapshot via anchorClose fallback', () => {
+    const hist = [
+      { close: undefined, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.0 },
+      { close: 100, weekly_em: 1.5 },
+    ];
+    const r = computeIVTrend(hist, 100);
+    expect(['up','down','flat','empty']).toContain(r.kind);
+  });
+
+  test('falls back to "empty" when all weekly_em are non-numeric', () => {
+    const hist = [
+      { close: 100 }, { close: 100 }, { close: 100 }, { close: 100 },
+    ];
+    expect(computeIVTrend(hist, 100).kind).toBe('empty');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// buildHistoryChart
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('buildHistoryChart', () => {
+  test('returns null when history is missing or has < 2 entries', () => {
+    expect(buildHistoryChart({})).toBeNull();
+    expect(buildHistoryChart({ history: [] })).toBeNull();
+    expect(buildHistoryChart({ history: [{date:'2026-01-01', close: 100, weekly_em: 1}] })).toBeNull();
+  });
+
+  test('returns valid SVG geometry for a flat series', () => {
+    const t = { history: Array.from({length: 5}, (_, i) => ({
+      date: `2026-01-0${i+1}`, close: 100, weekly_em: 1
+    })) };
+    const c = buildHistoryChart(t);
+    expect(c).not.toBeNull();
+    expect(c.points.length).toBe(5);
+    expect(c.breachCount).toBe(0);
+    // polyline string should have 5 "x,y" pairs
+    expect(c.linePolyline.split(' ').length).toBe(5);
+    // band polygon: 5 upper + 5 lower = 10 pairs
+    expect(c.bandPolygon.split(' ').length).toBe(10);
+    // every coordinate must be a finite number
+    for (const pair of c.linePolyline.split(' ')) {
+      const [x, y] = pair.split(',').map(Number);
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+    }
+  });
+
+  test('detects up-breach when close jumps above prior upper band', () => {
+    const t = { history: [
+      { date: 'd1', close: 100, weekly_em: 1 },
+      { date: 'd2', close: 102, weekly_em: 1 }, // 102 > 100 + 1
+      { date: 'd3', close: 102, weekly_em: 1 },
+    ] };
+    const c = buildHistoryChart(t);
+    expect(c.breachCount).toBe(1);
+    expect(c.breachMarkers[0].color).toBe('#ef5350');
+    expect(c.breachMarkers[0].title).toMatch(/broke above/);
+  });
+
+  test('detects down-breach when close falls below prior lower band', () => {
+    const t = { history: [
+      { date: 'd1', close: 100, weekly_em: 1 },
+      { date: 'd2', close: 98,  weekly_em: 1 }, // 98 < 100 - 1
+      { date: 'd3', close: 98,  weekly_em: 1 },
+    ] };
+    const c = buildHistoryChart(t);
+    expect(c.breachCount).toBe(1);
+    expect(c.breachMarkers[0].color).toBe('#00d4aa');
+    expect(c.breachMarkers[0].title).toMatch(/broke below/);
+  });
+
+  test('clamps to maxPoints', () => {
+    const hist = Array.from({length: 50}, (_, i) => ({
+      date: `2026-01-${String(i+1).padStart(2, '0')}`, close: 100, weekly_em: 1
+    }));
+    const c = buildHistoryChart({ history: hist }, 12);
+    expect(c.points.length).toBe(12);
+  });
+
+  test('drops snapshots with non-finite close or weekly_em', () => {
+    const hist = [
+      { date: 'd1', close: 100, weekly_em: 1 },
+      { date: 'd2', close: null, weekly_em: 1 },
+      { date: 'd3', close: 100, weekly_em: 'oops' },
+      { date: 'd4', close: 100, weekly_em: 1 },
+    ];
+    const c = buildHistoryChart({ history: hist });
+    expect(c.points.length).toBe(2);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// biasBreakdown
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('biasBreakdown', () => {
+  test('counts bull/bear/mixed buckets', () => {
+    const rows = [
+      { bias: 'bull' },
+      { bias: 'bull' },
+      { bias: 'bear' },
+      { bias: null },
+      { bias: undefined },
+      { bias: 'mixed' },
+    ];
+    const b = biasBreakdown(rows);
+    expect(b.bull).toBe(2);
+    expect(b.bear).toBe(1);
+    expect(b.mixed).toBe(3);
+  });
+
+  test('zero on empty input', () => {
+    expect(biasBreakdown([])).toEqual({ bull: 0, bear: 0, mixed: 0 });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Default sort behavior — verify the comparator formula matches our spec.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('default sort (position ASC)', () => {
+  test('rows sort by position ascending — buy zones first', () => {
+    const rows = [
+      { symbol: 'AAA', position: 80 },
+      { symbol: 'BBB', position: 5 },
+      { symbol: 'CCC', position: 50 },
+      { symbol: 'DDD', position: -10 },
+      { symbol: 'EEE', position: 110 },
+    ];
+    rows.sort((a, b) => a.position - b.position);
+    expect(rows.map(r => r.symbol)).toEqual(['DDD', 'BBB', 'CCC', 'AAA', 'EEE']);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Alert-tag filter logic — test with the same predicate the page uses
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('alert-tag filter logic', () => {
+  // Mirrors the predicate in buildRows() — kept in sync intentionally.
+  function passes(active, position) {
+    if (active.size === 0) return true;
+    const isBuy      = position <= 20;
+    const isExtended = position >= 85 && position <= 100;
+    const isOutside  = position < 0 || position > 100;
+    return (active.has('buy')      && isBuy)
+        || (active.has('extended') && isExtended)
+        || (active.has('outside')  && isOutside);
+  }
+
+  test('no chips active = pass-through', () => {
+    expect(passes(new Set(), 50)).toBe(true);
+    expect(passes(new Set(), -5)).toBe(true);
+    expect(passes(new Set(), 150)).toBe(true);
+  });
+
+  test('buy chip = position ≤ 20 (inclusive)', () => {
+    const f = new Set(['buy']);
+    expect(passes(f, 0)).toBe(true);
+    expect(passes(f, 20)).toBe(true);
+    expect(passes(f, 21)).toBe(false);
+    // position < 0 still counts as buy (below low = below EM range = oversold)
+    expect(passes(f, -5)).toBe(true);
+  });
+
+  test('extended chip = 85 ≤ position ≤ 100 (excludes outside)', () => {
+    const f = new Set(['extended']);
+    expect(passes(f, 84)).toBe(false);
+    expect(passes(f, 85)).toBe(true);
+    expect(passes(f, 100)).toBe(true);
+    expect(passes(f, 101)).toBe(false);
+  });
+
+  test('outside chip = position < 0 or > 100', () => {
+    const f = new Set(['outside']);
+    expect(passes(f, -1)).toBe(true);
+    expect(passes(f, 0)).toBe(false);
+    expect(passes(f, 100)).toBe(false);
+    expect(passes(f, 101)).toBe(true);
+  });
+
+  test('multi-toggle (buy + extended) is OR', () => {
+    const f = new Set(['buy', 'extended']);
+    expect(passes(f, 10)).toBe(true);   // buy
+    expect(passes(f, 90)).toBe(true);   // extended
+    expect(passes(f, 50)).toBe(false);  // neither
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Real-data smoke check (skipped if data file absent / CI w/o data)
+// ──────────────────────────────────────────────────────────────────────────
+
+const DATA_FILE = path.join(__dirname, '..', 'data', 'expected-moves.json');
+const realData = fs.existsSync(DATA_FILE) ? JSON.parse(fs.readFileSync(DATA_FILE, 'utf8')) : null;
+const describeReal = realData ? describe : describe.skip;
+
+describeReal('Real data smoke', () => {
+  test('every ticker with history of length ≥ 2 yields a non-null chart', () => {
+    const tickers = realData.tickers || {};
+    let charted = 0, total = 0;
+    for (const [, t] of Object.entries(tickers)) {
+      if (!Array.isArray(t.history) || t.history.length < 2) continue;
+      total++;
+      const c = buildHistoryChart(t);
+      if (c) charted++;
+    }
+    expect(total).toBeGreaterThan(0);
+    expect(charted).toBe(total);
+  });
+
+  test('IV trend either gives empty (insufficient data) or a finite delta', () => {
+    const tickers = realData.tickers || {};
+    let count = 0;
+    for (const [, t] of Object.entries(tickers)) {
+      const tr = computeIVTrend(t.history, t.close);
+      if (tr.kind === 'empty') {
+        expect(tr.delta).toBeNull();
+      } else {
+        expect(Number.isFinite(tr.delta)).toBe(true);
+      }
+      count++;
+    }
+    expect(count).toBeGreaterThan(0);
+  });
+});

--- a/v1/expected-moves.html
+++ b/v1/expected-moves.html
@@ -245,6 +245,72 @@
     0%, 100% { opacity: 1; }
     50% { opacity: 0.7; }
   }
+  /* Stale data banner — top of page when EM data > 48h old.
+     Existing red timestamp was easy to miss (Mar 27 staleness incident). */
+  .stale-banner {
+    background: rgba(239,83,80,0.14);
+    border: 1px solid rgba(239,83,80,0.45);
+    color: var(--red);
+    padding: 10px 16px;
+    border-radius: 8px;
+    font-size: 12px;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .stale-banner .stale-icon { font-size: 14px; }
+
+  /* IV trend pill rendered in the IV Trend column */
+  .iv-trend {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.04);
+  }
+  .iv-trend.up    { color: #ef5350; background: rgba(239,83,80,0.10); }
+  .iv-trend.down  { color: #4caf50; background: rgba(76,175,80,0.10); }
+  .iv-trend.flat  { color: var(--text-dim); }
+  .iv-trend.empty { color: var(--text-dim); opacity: 0.5; }
+
+  /* Bias breakdown pills shown inside stat-sub */
+  .bias-pill {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    font-weight: 700;
+    margin: 0 2px;
+    letter-spacing: 0.4px;
+  }
+  .bias-pill.bull  { color: #4caf50; background: rgba(76,175,80,0.14); }
+  .bias-pill.bear  { color: #f44336; background: rgba(244,67,54,0.14); }
+  .bias-pill.mixed { color: var(--text-dim); background: rgba(255,255,255,0.05); }
+
+  /* Detail-modal history chart (close vs predicted EM band over the last N days) */
+  .em-history-box {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: #0c0c18;
+    padding: 12px 16px 16px;
+    margin-bottom: 20px;
+  }
+  .em-history-head {
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: 11px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 1px; color: var(--text-dim); margin-bottom: 8px;
+  }
+  .em-history-caption {
+    margin-top: 6px; font-size: 11px; color: var(--text-dim);
+    display: flex; gap: 14px; flex-wrap: wrap;
+  }
+  .em-history-caption strong { color: var(--text); font-weight: 600; }
+  .em-history-svg { width: 100%; height: 140px; display: block; }
+
   /* === DETAIL MODAL === */
   .modal-overlay {
     position: fixed; inset: 0; z-index: 1000;
@@ -303,6 +369,8 @@
     <div class="updated" id="em-updated"></div>
   </div>
 
+  <div id="stale-banner-slot"></div>
+
   <div class="stats-row" id="stats-row"></div>
 
   <div class="legend">
@@ -330,6 +398,13 @@
     </div>
   </div>
 
+  <div class="tier-tabs" style="margin-bottom:16px;" aria-label="Alert filter chips">
+    <span style="color:var(--text-dim);font-size:11px;align-self:center;margin-right:4px;">Show only:</span>
+    <button class="tier-tab alert-filter-tab" data-alertfilter="buy">🟢 Buy zone</button>
+    <button class="tier-tab alert-filter-tab" data-alertfilter="extended">🔴 Extended</button>
+    <button class="tier-tab alert-filter-tab" data-alertfilter="outside">⚡ Outside EM</button>
+  </div>
+
   <div class="em-table-wrap">
     <table>
       <thead>
@@ -343,7 +418,7 @@
           <th data-col="upper">High</th>
           <th data-col="position" style="min-width:140px;">Position in Range</th>
           <th data-col="risk">Risk Level</th>
-          <th data-col="riskbar" style="min-width:130px;">Risk Meter</th>
+          <th data-col="ivtrend" style="min-width:110px;" title="Implied vol trend: avg weekly EM% over last 5 days vs prior 5 days">IV Trend</th>
           <th data-col="bias">Bias</th>
         </tr>
       </thead>
@@ -375,6 +450,7 @@ let watchlistData = [];
 let currentTier = 'weekly';
 let sortCol = null;
 let currentFilter = 'all';
+const activeAlertFilters = new Set();
 const TOP10_SP = ['AAPL','MSFT','NVDA','AMZN','META','GOOGL','GOOG','TSLA','BRK B','AVGO'];
 const INDICES = ['SPX','SPY','QQQ','IWM','DIA','TLT','HYG','LQD','GLD','USO','UNG','IBIT'];
 let sortAsc = false;
@@ -393,10 +469,17 @@ async function loadData() {
     const updatedDate = new Date(em.updated);
     const ageHours = (Date.now() - updatedDate.getTime()) / 3600000;
     let emLabel = `EM Ranges: ${updatedDate.toLocaleString('en-US', { month:'short', day:'numeric', hour:'numeric', minute:'2-digit', hour12:true, timeZone:'America/New_York' })} ET`;
-    // Stale data warning: log only, no UI banner
+    const banner = document.getElementById('stale-banner-slot');
+    banner.innerHTML = '';
     if (ageHours > 48) {
       updatedEl.style.color = 'var(--red)';
-      emLabel += ` (${Math.round(ageHours / 24)}d old)`;
+      const dAge = Math.round(ageHours / 24);
+      emLabel += ` (${dAge}d old)`;
+      banner.innerHTML = `<div class="stale-banner">
+        <span class="stale-icon">⚠️</span>
+        <span><strong>Expected Move data is ${dAge} day${dAge === 1 ? '' : 's'} old.</strong>
+        Bands and risk levels below may be misleading. Run <code>scripts/update-expected-moves.py</code> to refresh.</span>
+      </div>`;
       console.warn(`[EM] Data stale: ${Math.round(ageHours)}h old. Run update-expected-moves.py to refresh.`);
     } else if (ageHours > 24) {
       updatedEl.style.color = 'var(--orange)';
@@ -446,7 +529,7 @@ function buildRows() {
     const currentPrice = btPrices.price(sym) ?? wl?.price ?? t.close;
     const change = btPrices.change(sym) ?? wl?.change ?? 0;
 
-    // Filter
+    // Symbol-category filter (single-pick)
     if (currentFilter === 'indices' && !INDICES.includes(sym)) continue;
     if (currentFilter === 'top10' && !TOP10_SP.includes(sym)) continue;
     if (currentFilter === 'watchlist' && !wl) continue;
@@ -459,8 +542,22 @@ function buildRows() {
     const position = range > 0 ? ((currentPrice - lo) / range) * 100 : 50;
     const clampedPos = Math.max(0, Math.min(100, position));
 
+    // Alert-tag filter (multi-toggle, OR within set, AND with category)
+    if (activeAlertFilters.size > 0) {
+      const isBuy      = position <= 20;
+      const isExtended = position >= 85 && position <= 100;
+      const isOutside  = position < 0 || position > 100;
+      const ok = (activeAlertFilters.has('buy')      && isBuy)
+              || (activeAlertFilters.has('extended') && isExtended)
+              || (activeAlertFilters.has('outside')  && isOutside);
+      if (!ok) continue;
+    }
+
     const risk = getRiskLabel(position);
     const riskColor = getRiskColor(position);
+
+    // IV trend: avg weekly_em% over last 5 history snapshots vs prior 5
+    const ivTrend = computeIVTrend(t.history, t.close);
 
     // Bias from watchlist
     let bias = null;
@@ -494,12 +591,52 @@ function buildRows() {
       strike: t.strike,
       expiry: t.weekly_expiry,
       proxy: t.futures_proxy,
+      bias: bias,
       biasHtml: biasHtml,
+      ivTrend: ivTrend,
     });
   }
 
   return rows;
 }
+
+// Compute IV trend signal from `history[]` snapshots.
+// Compares mean weekly_em% over last 5 entries vs prior 5 entries.
+// Exposed on `window` for unit tests.
+function computeIVTrend(history, anchorClose) {
+  if (!Array.isArray(history) || history.length < 4) {
+    return { kind: 'empty', delta: null, label: '—', title: 'Insufficient history (need ≥4 daily snapshots)' };
+  }
+  const pctOf = (snap) => {
+    if (!snap || typeof snap.weekly_em !== 'number') return null;
+    const denom = (typeof snap.close === 'number' && snap.close > 0) ? snap.close : anchorClose;
+    if (!denom) return null;
+    return (snap.weekly_em / denom) * 100;
+  };
+  const pcts = history.map(pctOf).filter(v => v != null && Number.isFinite(v));
+  if (pcts.length < 4) {
+    return { kind: 'empty', delta: null, label: '—', title: 'Insufficient history (need ≥4 daily snapshots)' };
+  }
+  const recentN = Math.min(5, Math.floor(pcts.length / 2));
+  const recent = pcts.slice(-recentN);
+  const prior  = pcts.slice(-recentN * 2, -recentN);
+  if (!prior.length) {
+    return { kind: 'empty', delta: null, label: '—', title: 'Insufficient history (need ≥4 daily snapshots)' };
+  }
+  const mean = (arr) => arr.reduce((s, v) => s + v, 0) / arr.length;
+  const r = mean(recent);
+  const p = mean(prior);
+  if (!p) {
+    return { kind: 'empty', delta: null, label: '—', title: 'Insufficient history' };
+  }
+  const delta = ((r - p) / p) * 100;
+  const sign = delta >= 0 ? '+' : '−';
+  const mag = Math.abs(delta).toFixed(1);
+  if (delta >= 5)  return { kind: 'up',   delta, label: `▲ ${sign}${mag}%`, title: `IV expanding: avg ${recentN}d EM% rose ${mag}% vs prior ${recentN}d` };
+  if (delta <= -5) return { kind: 'down', delta, label: `▼ ${sign}${mag}%`, title: `IV contracting: avg ${recentN}d EM% fell ${mag}% vs prior ${recentN}d` };
+  return { kind: 'flat', delta, label: `— ${sign}${mag}%`, title: `IV roughly flat (≤5% delta over ${recentN}d window)` };
+}
+window.computeIVTrend = computeIVTrend;
 
 function render() {
   if (!emData.tickers) return;
@@ -515,8 +652,8 @@ function renderStats(rows) {
   const avgPct = rows.reduce((s, r) => s + (r.pct || 0), 0) / rows.length;
   const maxEM = rows.reduce((max, r) => (r.pct || 0) > (max.pct || 0) ? r : max, rows[0]);
   const minEM = rows.reduce((min, r) => (r.pct || 0) < (min.pct || 0) ? r : min, rows[0]);
-  const extended = rows.filter(r => r.position > 85).length;
-  const buyZone = rows.filter(r => r.position <= 20).length;
+  const extendedRows = rows.filter(r => r.position > 85);
+  const buyRows = rows.filter(r => r.position <= 20);
 
   document.getElementById('stats-row').innerHTML = `
     <div class="stat-card">
@@ -531,15 +668,37 @@ function renderStats(rows) {
     </div>
     <div class="stat-card">
       <div class="stat-label">🟢 Buy Zone</div>
-      <div class="stat-value" style="color:${buyZone > 0 ? '#4caf50' : 'var(--text-dim)'}">${buyZone}</div>
-      <div class="stat-sub">near low of EM range</div>
+      <div class="stat-value" style="color:${buyRows.length > 0 ? '#4caf50' : 'var(--text-dim)'}">${buyRows.length}</div>
+      <div class="stat-sub">${buyRows.length ? biasBreakdownHtml(buyRows) : 'near low of EM range'}</div>
     </div>
     <div class="stat-card">
       <div class="stat-label">🔴 Extended</div>
-      <div class="stat-value" style="color:${extended > 0 ? 'var(--red)' : 'var(--text-dim)'}">${extended}</div>
-      <div class="stat-sub">at/above EM ceiling</div>
+      <div class="stat-value" style="color:${extendedRows.length > 0 ? 'var(--red)' : 'var(--text-dim)'}">${extendedRows.length}</div>
+      <div class="stat-sub">${extendedRows.length ? biasBreakdownHtml(extendedRows) : 'at/above EM ceiling'}</div>
     </div>
   `;
+}
+
+// Compute counts of {bull, bear, mixed} from a list of rows.
+// Exposed on window for tests.
+function biasBreakdown(rows) {
+  let bull = 0, bear = 0, mixed = 0;
+  for (const r of rows) {
+    if (r.bias === 'bull') bull++;
+    else if (r.bias === 'bear') bear++;
+    else mixed++;
+  }
+  return { bull, bear, mixed };
+}
+window.biasBreakdown = biasBreakdown;
+
+function biasBreakdownHtml(rows) {
+  const b = biasBreakdown(rows);
+  const parts = [];
+  if (b.bull)  parts.push(`<span class="bias-pill bull">${b.bull} BULL</span>`);
+  if (b.bear)  parts.push(`<span class="bias-pill bear">${b.bear} BEAR</span>`);
+  if (b.mixed) parts.push(`<span class="bias-pill mixed">${b.mixed} MIXED</span>`);
+  return parts.join(' ');
 }
 
 function renderTable(rows) {
@@ -590,18 +749,18 @@ function renderTable(rows) {
         <div class="dim" style="margin-top:3px;">${r.position.toFixed(0)}% of range</div>
       </td>
       <td><span class="risk-badge" style="color:${r.risk.color};background:${r.risk.bg};border:1px solid ${r.risk.color}40;">${r.risk.text}</span></td>
-      <td>
-        <div class="risk-bar-wrap">
-          <div class="risk-fill" style="width:${Math.max(4, Math.min(100, r.position))}%;background:${needleColor};"></div>
-        </div>
-      </td>
+      <td><span class="iv-trend ${r.ivTrend.kind}" title="${r.ivTrend.title}">${r.ivTrend.label}</span></td>
       <td style="white-space:nowrap;">${r.biasHtml}</td>
     </tr>`;
   }).join('');
 }
 
 function sortRows(rows) {
-  if (!sortCol) return; // No sort active — keep default data order
+  // Default sort when no user sort is active: position ASC = buy zones at top.
+  if (!sortCol) {
+    rows.sort((a, b) => a.position - b.position);
+    return;
+  }
   const col = sortCol;
   rows.sort((a, b) => {
     let va, vb;
@@ -615,7 +774,12 @@ function sortRows(rows) {
       case 'upper': va = a.upper; vb = b.upper; break;
       case 'position': va = a.position; vb = b.position; break;
       case 'risk': va = a.position; vb = b.position; break;
-      case 'riskbar': va = a.position; vb = b.position; break;
+      case 'ivtrend': va = a.ivTrend?.delta ?? -Infinity; vb = b.ivTrend?.delta ?? -Infinity; break;
+      case 'bias':
+        // Bull > Mixed > Bear when ascending — so a "bias asc" sort surfaces best longs first
+        va = a.bias === 'bull' ? 2 : a.bias === 'bear' ? 0 : 1;
+        vb = b.bias === 'bull' ? 2 : b.bias === 'bear' ? 0 : 1;
+        break;
       default: va = a.position; vb = b.position;
     }
     if (typeof va === 'string') return sortAsc ? va.localeCompare(vb) : vb.localeCompare(va);
@@ -639,6 +803,21 @@ document.querySelectorAll('.filter-tab[data-filter]').forEach(btn => {
     document.querySelectorAll('.filter-tab[data-filter]').forEach(b => b.classList.remove('active'));
     btn.classList.add('active');
     currentFilter = btn.dataset.filter;
+    render();
+  });
+});
+
+// Alert-tag filter chips (multi-toggle, OR within set, AND with category filter)
+document.querySelectorAll('.alert-filter-tab[data-alertfilter]').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const key = btn.dataset.alertfilter;
+    if (activeAlertFilters.has(key)) {
+      activeAlertFilters.delete(key);
+      btn.classList.remove('active');
+    } else {
+      activeAlertFilters.add(key);
+      btn.classList.add('active');
+    }
     render();
   });
 });
@@ -701,6 +880,93 @@ const EXCHANGE_MAP = {
   'GLD':'AMEX','SLV':'AMEX','URA':'AMEX','USO':'AMEX','UNG':'AMEX','IBIT':'NASDAQ',
   'EQIX':'NASDAQ','DLR':'NYSE','AMT':'NYSE',
 };
+
+// Render the per-ticker history box: SVG showing close vs predicted EM band
+// across the last N daily snapshots, plus breach markers and an IV-trend line.
+// Returns empty string when there isn't enough history (< 2 snapshots).
+// Exposed on window for unit tests.
+function renderHistoryBox(symbol, t) {
+  const chart = buildHistoryChart(t, 30);
+  if (!chart) return '';
+  const trendBadge = t.history && t.history.length >= 4
+    ? (() => {
+        const tr = computeIVTrend(t.history, t.close);
+        return `<span class="iv-trend ${tr.kind}" title="${tr.title}">${tr.label}</span>`;
+      })()
+    : '';
+  return `<div class="em-history-box">
+    <div class="em-history-head">
+      <span>${symbol} — Last ${chart.points.length}d · close vs predicted weekly EM band</span>
+      ${trendBadge}
+    </div>
+    <svg class="em-history-svg" viewBox="0 0 ${chart.w} ${chart.h}" preserveAspectRatio="none">
+      <polygon points="${chart.bandPolygon}" fill="rgba(0,212,170,0.10)" stroke="rgba(0,212,170,0.30)" stroke-width="1"/>
+      <polyline points="${chart.linePolyline}" fill="none" stroke="#ffd700" stroke-width="1.5"/>
+      ${chart.breachMarkers.map(m =>
+        `<circle cx="${m.x}" cy="${m.y}" r="3" fill="${m.color}" stroke="#0c0c18" stroke-width="1"><title>${m.title}</title></circle>`
+      ).join('')}
+    </svg>
+    <div class="em-history-caption">
+      <span><strong>${chart.points.length}</strong> daily snapshots</span>
+      <span><strong>${chart.breachCount}</strong> band breach${chart.breachCount === 1 ? '' : 'es'}</span>
+      <span>Range: $${chart.lo.toFixed(2)} – $${chart.hi.toFixed(2)}</span>
+    </div>
+  </div>`;
+}
+window.renderHistoryBox = renderHistoryBox;
+
+// Pure data-only helper that produces SVG geometry from a ticker's history array.
+// Exposed on window for unit tests; returns null when input is unusable.
+function buildHistoryChart(t, maxPoints = 30) {
+  const history = Array.isArray(t.history) ? t.history.slice(-maxPoints) : [];
+  if (history.length < 2) return null;
+
+  const W = 360, H = 100, padX = 4, padY = 6;
+  const innerW = W - padX * 2;
+  const innerH = H - padY * 2;
+
+  const points = history.map(h => {
+    if (h == null) return null;
+    if (h.close == null || h.weekly_em == null) return null;
+    const close = Number(h.close);
+    const em    = Number(h.weekly_em);
+    if (!Number.isFinite(close) || !Number.isFinite(em)) return null;
+    return { date: h.date, close, em, upper: close + em, lower: close - em };
+  }).filter(Boolean);
+  if (points.length < 2) return null;
+
+  const lo = Math.min(...points.map(p => p.lower));
+  const hi = Math.max(...points.map(p => p.upper));
+  const span = hi - lo || 1;
+  const x = (i) => padX + (i / (points.length - 1)) * innerW;
+  const y = (val) => padY + (1 - (val - lo) / span) * innerH;
+
+  const linePolyline = points.map((p, i) => `${x(i).toFixed(2)},${y(p.close).toFixed(2)}`).join(' ');
+  const upperPath = points.map((p, i) => `${x(i).toFixed(2)},${y(p.upper).toFixed(2)}`);
+  const lowerPath = points.map((p, i) => `${x(i).toFixed(2)},${y(p.lower).toFixed(2)}`).reverse();
+  const bandPolygon = upperPath.concat(lowerPath).join(' ');
+
+  // Breach: today's close moved beyond yesterday's predicted band
+  const breachMarkers = [];
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const cur  = points[i];
+    if (cur.close > prev.upper) {
+      breachMarkers.push({ x: x(i).toFixed(2), y: y(cur.close).toFixed(2),
+        color: '#ef5350', title: `${cur.date}: $${cur.close.toFixed(2)} broke above prior upper $${prev.upper.toFixed(2)}` });
+    } else if (cur.close < prev.lower) {
+      breachMarkers.push({ x: x(i).toFixed(2), y: y(cur.close).toFixed(2),
+        color: '#00d4aa', title: `${cur.date}: $${cur.close.toFixed(2)} broke below prior lower $${prev.lower.toFixed(2)}` });
+    }
+  }
+
+  return {
+    w: W, h: H, lo, hi, points,
+    linePolyline, bandPolygon,
+    breachMarkers, breachCount: breachMarkers.length
+  };
+}
+window.buildHistoryChart = buildHistoryChart;
 
 function openEMDetail(symbol) {
   const t = emData.tickers?.[symbol];
@@ -771,6 +1037,7 @@ function openEMDetail(symbol) {
         <div class="chart-label">${symbol} — Daily Chart</div>
         <div id="em-tv-chart"></div>
       </div>
+      ${renderHistoryBox(symbol, t)}
       <div class="info-row">${tierCards}</div>`;
   }
 


### PR DESCRIPTION
## Summary

Surface the data the EM producer already writes but the page never showed, and tighten triage UX so the most actionable rows are obvious at a glance. Single-file change to `v1/expected-moves.html` plus a new test file and openspec proposal.

## Why

The EM page is a **triage tool** ("who's at the bottom of their range, who's stretched"), but four pieces of data the producer already writes were unused or under-used:

1. **`history[]`** (up to 33 daily snapshots per ticker) was never rendered. Detail modal showed only current tier cards. Traders couldn't see whether a ticker had been near support for one day or four weeks straight.
2. **`weekly_em` over time** — page had no sense of whether implied vol was expanding or contracting.
3. **`watchlist[].bias`** — used per row, but the stats cards counted buy-zone tickers blindly. A bullish-biased ticker in buy zone is the highest-conviction long setup; mixed in with bears, the count was muddied.
4. **The Risk Meter column duplicated the Position in Range column** — both rendered a colored bar whose width is `position%`. Dead pixel real estate.

Plus three ergonomics gaps:

5. No alert-tag filter — couldn't show only buy zones / extended / outside EM.
6. No useful default sort — JSON insertion order meant buy-zones didn't float to the top.
7. Stale-data warning was hidden in the timestamp color (Mar 27 staleness incident showed users miss it).

## What changed

| Change | File | Notes |
|---|---|---|
| **30-day history chart in detail modal** | `v1/expected-moves.html` | Inline SVG: close line + shaded predicted EM band + breach markers (red = up-breach, cyan = down-breach). Uses `history[]` already on every ticker. |
| **IV Trend column** (replaces Risk Meter) | `v1/expected-moves.html` | Avg weekly EM% over last 5 snapshots vs prior 5. Shows ▲/▼/— with delta %. Sortable. |
| **Bias-aware Buy Zone / Extended stats** | `v1/expected-moves.html` | `8 (3 BULL · 5 MIXED)` instead of just `8`. |
| **Alert-tag filter chips** | `v1/expected-moves.html` | 🟢 Buy zone / 🔴 Extended / ⚡ Outside EM. Multi-toggle. ANDed with category filter. |
| **Smart default sort** | `v1/expected-moves.html` | `position` ASC when no user sort. Buy zones at top. Header click cycle unchanged. |
| **Stale-data banner** | `v1/expected-moves.html` | Top-of-page red banner when `ageHours > 48`, in addition to the existing red timestamp. |
| **Tests** | `tests/em-page-improvements.test.js` | 22 new Jest tests. |
| **OpenSpec** | `openspec/changes/em-history-sparkline/OPENSPEC.md` + `openspec/INDEX.md` | Problem, design, file touches, test plan, risk, rollout. INDEX moves "EM History Sparkline" Planned → Active. |

## Test results

| Suite | Before | After |
|---|---|---|
| `cd tests && npx jest` | 137 / 137 | **159 / 159** ✅ |
| `node tests/test-em-formula.js` | 167 pass / 42 fail | 167 pass / 42 fail (unchanged — pre-existing data-freshness asserts) |

22 new tests cover:

- `computeIVTrend` — insufficient data, flat, expansion, contraction, anchor-close fallback, all-non-numeric.
- `buildHistoryChart` — null guard, finite-coord geometry, up-breach detection, down-breach detection, max-points clamp, non-finite drops.
- `biasBreakdown` — bull/bear/mixed counts, empty input.
- Default sort comparator (position ASC).
- Alert-filter predicate (no-chip pass-through, each chip alone, multi-OR).
- Real-data smoke against `data/expected-moves.json` (every ticker with usable history charts cleanly; every IV trend yields a finite delta or empty).

## Risk / breaking-change notes

- **Default sort changes** what the page shows on load (was JSON order; now position ASC). Mitigated by the existing 3-state header cycle — third click of any column returns to the new default.
- **Risk Meter column removed.** Position in Range column already conveyed the same info more clearly.
- **No producer changes.** All data already exists in `data/expected-moves.json`. No schema migration.
- **No new dependencies.** SVG is rendered inline; no chart library.

## Out of scope (follow-ups)

- v2 SPA parity (`js/pages/expected-moves.js`) — separate PR.
- Mobile card layout at ≤768px.
- CSV export.
- Bias-by-tier ("bullish-biased buy-zone weekly vs monthly").
- EM-breach Telegram alerts (already tracked in `em-reliability-improvements`).

## Manual verification

```
cd breakingtrades-dashboard
python3 -m http.server 8989
open http://localhost:8989/v1/expected-moves.html
```

- Buy zones float to top.
- Click a ticker with history → modal shows price-vs-band SVG with breach dots.
- Toggle 🟢 Buy zone chip → table narrows to ≤20% position rows.
- Switch tier → default sort still applies.
- Mock `data/expected-moves.json` with old `updated` (e.g. 2024) → red banner appears.

Closes the Planned item "EM History Sparkline — Inline table sparkline still planned" in `openspec/INDEX.md`.